### PR TITLE
change gson to disable html escaping erdjava

### DIFF
--- a/erdjava/src/main/java/elrond/Transaction.java
+++ b/erdjava/src/main/java/elrond/Transaction.java
@@ -8,6 +8,7 @@ import java.util.Map;
 
 import com.google.gson.Gson;
 
+import com.google.gson.GsonBuilder;
 import org.bouncycastle.util.encoders.Base64;
 
 import elrond.Exceptions.AddressException;
@@ -17,7 +18,7 @@ import elrond.Exceptions.ProxyRequestException;
 
 public class Transaction {
     public static final int VERSION = 1;
-    private static final Gson gson = new Gson();
+    private static final Gson gson = new GsonBuilder().disableHtmlEscaping().create();
 
     private long nonce;
     private BigInteger value;

--- a/erdjava/src/test/java/elrond/TransactionTest.java
+++ b/erdjava/src/test/java/elrond/TransactionTest.java
@@ -10,7 +10,7 @@ public class TransactionTest {
     public void shouldSerialize() throws Exception {
         Transaction transaction = new Transaction();
 
-        // Without data (memo) field
+        // Without data field
         transaction.setNonce(0);
         transaction.setValue(new BigInteger("42"));
         transaction.setSender(Address.fromBech32("erd1l453hd0gt5gzdp7czpuall8ggt2dcv5zwmfdf3sd3lguxseux2fsmsgldz"));
@@ -22,7 +22,7 @@ public class TransactionTest {
         String expected = "{'nonce':0,'value':'42','receiver':'erd1cux02zersde0l7hhklzhywcxk4u9n4py5tdxyx7vrvhnza2r4gmq4vw35r','sender':'erd1l453hd0gt5gzdp7czpuall8ggt2dcv5zwmfdf3sd3lguxseux2fsmsgldz','gasPrice':1000000000,'gasLimit':50000,'chainID':'1','version':1}".replace('\'', '"');
         assertEquals(expected, transaction.serialize());
 
-        // With data (memo) field
+        // With data field
         transaction.setData("foobar");
         expected = "{'nonce':0,'value':'42','receiver':'erd1cux02zersde0l7hhklzhywcxk4u9n4py5tdxyx7vrvhnza2r4gmq4vw35r','sender':'erd1l453hd0gt5gzdp7czpuall8ggt2dcv5zwmfdf3sd3lguxseux2fsmsgldz','gasPrice':1000000000,'gasLimit':50000,'data':'Zm9vYmFy','chainID':'1','version':1}".replace('\'', '"');
         assertEquals(expected, transaction.serialize());
@@ -33,7 +33,7 @@ public class TransactionTest {
         String alicePrivateKey = "1a927e2af5306a9bb2ea777f73e06ecc0ac9aaa72fb4ea3fecf659451394cccf";
         Wallet wallet = new Wallet(alicePrivateKey);
 
-        // With data (memo) field
+        // With data field
         Transaction transaction = new Transaction();
         transaction.setNonce(7);
         transaction.setValue(new BigInteger("10000000000000000000"));
@@ -50,7 +50,7 @@ public class TransactionTest {
         assertEquals(expectedSignature, transaction.getSignature());
         assertEquals(expectedJson, transaction.serialize());
 
-        // Without data (memo) field
+        // Without data field
         transaction = new Transaction();
         transaction.setNonce(8);
         transaction.setValue(new BigInteger("10000000000000000000"));

--- a/erdjava/src/test/java/elrond/TransactionTest.java
+++ b/erdjava/src/test/java/elrond/TransactionTest.java
@@ -41,12 +41,12 @@ public class TransactionTest {
         transaction.setReceiver(Address.fromBech32("erd1cux02zersde0l7hhklzhywcxk4u9n4py5tdxyx7vrvhnza2r4gmq4vw35r"));
         transaction.setGasPrice(1000000000);
         transaction.setGasLimit(70000);
-        transaction.setData("for the book");
+        transaction.setData("for the book with stake");
         transaction.setChainID("1");
         transaction.sign(wallet);
 
-        String expectedSignature = "1702bb7696f992525fb77597956dd74059b5b01e88c813066ad1f6053c6afca97d6eaf7039b2a21cccc7d73b3e5959be4f4c16f862438c7d61a30c91e3d16c01";
-        String expectedJson = "{'nonce':7,'value':'10000000000000000000','receiver':'erd1cux02zersde0l7hhklzhywcxk4u9n4py5tdxyx7vrvhnza2r4gmq4vw35r','sender':'erd1l453hd0gt5gzdp7czpuall8ggt2dcv5zwmfdf3sd3lguxseux2fsmsgldz','gasPrice':1000000000,'gasLimit':70000,'data':'Zm9yIHRoZSBib29r','chainID':'1','version':1,'signature':'1702bb7696f992525fb77597956dd74059b5b01e88c813066ad1f6053c6afca97d6eaf7039b2a21cccc7d73b3e5959be4f4c16f862438c7d61a30c91e3d16c01'}".replace('\'', '"');
+        String expectedSignature = "096c571889352947f285632d79f2b2ee1b81e7acd19ee20510d34002eba0f999b4720f50211b039dd40914284f84c14eb84815bb045c14dbed036f2e87431307";
+        String expectedJson = "{'nonce':7,'value':'10000000000000000000','receiver':'erd1cux02zersde0l7hhklzhywcxk4u9n4py5tdxyx7vrvhnza2r4gmq4vw35r','sender':'erd1l453hd0gt5gzdp7czpuall8ggt2dcv5zwmfdf3sd3lguxseux2fsmsgldz','gasPrice':1000000000,'gasLimit':70000,'data':'Zm9yIHRoZSBib29rIHdpdGggc3Rha2U=','chainID':'1','version':1,'signature':'096c571889352947f285632d79f2b2ee1b81e7acd19ee20510d34002eba0f999b4720f50211b039dd40914284f84c14eb84815bb045c14dbed036f2e87431307'}".replace('\'', '"');
         assertEquals(expectedSignature, transaction.getSignature());
         assertEquals(expectedJson, transaction.serialize());
 


### PR DESCRIPTION
Hi,

I've tried to send a transaction that have in data field a value that in base64 contains equal sign '=' . 
By default, Gson escapes HTML characters such as < >= etc leading to invalid signature of transaction.

I've changed the instance for gson to disable html escaping
I've also changed the transaction test with data (memo) field, to contain a special character after base64 encoding.

Regards,
Sorin Federiga
