### PR TITLE
Add PIP update prior installing dependencies

### DIFF
--- a/erdpy-up.py
+++ b/erdpy-up.py
@@ -155,6 +155,7 @@ def ensure_folder(folder):
 def install_erdpy():
     logger.info("Installing erdpy in virtual environment...")
     erpy_versioned = "erdpy" if not exact_version else f"erdpy=={exact_version}"
+    run_in_venv(["python3", "-m", "pip", "install", "--upgrade", "pip"])
     return_code = run_in_venv(["pip3", "install", "--no-cache-dir", erpy_versioned])
     if return_code != 0:
         raise InstallError("Could not install erdpy.")

--- a/erdpy-up.py
+++ b/erdpy-up.py
@@ -155,7 +155,9 @@ def ensure_folder(folder):
 def install_erdpy():
     logger.info("Installing erdpy in virtual environment...")
     erpy_versioned = "erdpy" if not exact_version else f"erdpy=={exact_version}"
-    run_in_venv(["python3", "-m", "pip", "install", "--upgrade", "pip"])
+    return_code = run_in_venv(["python3", "-m", "pip", "install", "--upgrade", "pip"])
+    if return_code != 0:
+        raise InstallError("Could not upgrade pip.")
     return_code = run_in_venv(["pip3", "install", "--no-cache-dir", erpy_versioned])
     if return_code != 0:
         raise InstallError("Could not install erdpy.")


### PR DESCRIPTION
With outdated PIP some packages fails to install, this line introduces a
fix to ensure the latest PIP version is available on the CLI.

Thanks @elrondnetwork_es for the guidance.