### PR TITLE
erdpy dns version --all

### DIFF
--- a/erdpy/cli_dns.py
+++ b/erdpy/cli_dns.py
@@ -27,7 +27,7 @@ def setup_parser(subparsers: Any) -> Any:
 
     sub = cli_shared.add_command_subparser(subparsers, "dns", "validate-name", "Asks one of the DNS contracts to validate a name. Can be useful before registering it.")
     _add_name_arg(sub)
-    sub.add_argument("--shard_id", default=0, help="shard id of the contract to call (default: %(default)s)")
+    sub.add_argument("--shard-id", default=0, help="shard id of the contract to call (default: %(default)s)")
     cli_shared.add_proxy_arg(sub)
     sub.set_defaults(func=dns_validate_name)
 
@@ -36,12 +36,13 @@ def setup_parser(subparsers: Any) -> Any:
     sub.set_defaults(func=get_name_hash)
 
     sub = cli_shared.add_command_subparser(subparsers, "dns", "registration-cost", "Gets the registration cost from a DNS smart contract, by default the one with shard id 0.")
-    sub.add_argument("--shard_id", default=0, help="shard id of the contract to call (default: %(default)s)")
+    sub.add_argument("--shard-id", default=0, help="shard id of the contract to call (default: %(default)s)")
     cli_shared.add_proxy_arg(sub)
     sub.set_defaults(func=get_registration_cost)
 
     sub = cli_shared.add_command_subparser(subparsers, "dns", "version", "Asks the contract for its version")
-    sub.add_argument("--shard_id", default=0, help="shard id of the contract to call (default: %(default)s)")
+    sub.add_argument("--shard-id", default=0, help="shard id of the contract to call (default: %(default)s)")
+    sub.add_argument("--all", action="store_true", default=False, help="prints a list of all DNS contracts and their current versions (default: %(default)s)")
     cli_shared.add_proxy_arg(sub)
     sub.set_defaults(func=get_version)
 
@@ -95,12 +96,22 @@ def get_registration_cost(args: Any):
 
 
 def get_version(args: Any):
-    print(version(args.shard_id, ElrondProxy(args.proxy)))
+    proxy = ElrondProxy(args.proxy)
+    if args.all:
+        t = PrettyTable(['Shard ID', 'Contract address (bech32)', 'Contract address (hex)', 'Version'])
+        for shard_id in range(0, 256):
+            address = compute_dns_address_for_shard_id(shard_id)
+            v = version(shard_id, proxy)
+            t.add_row([shard_id, address, address.hex(), v])
+        print(t)
+    else:
+        shard_id = int(args.shard_id)
+        print(version(shard_id, proxy))
 
 
 def print_dns_addresses_table(args: Any):
     t = PrettyTable(['Shard ID', 'Contract address (bech32)', 'Contract address (hex)'])
-    for i in range(0, 256):
-        address = compute_dns_address_for_shard_id(i)
-        t.add_row([i, address, address.hex()])
+    for shard_id in range(0, 256):
+        address = compute_dns_address_for_shard_id(shard_id)
+        t.add_row([shard_id, address, address.hex()])
     print(t)


### PR DESCRIPTION
Example usage:
`erdpy dns version --all --proxy https://testnet-gateway.elrond.com`

Output:
```
+----------+----------------------------------------------------------------+------------------------------------------------------------------+---------+
| Shard ID |                   Contract address (bech32)                    |                      Contract address (hex)                      | Version |
+----------+----------------------------------------------------------------+------------------------------------------------------------------+---------+
|    0     | erd1qqqqqqqqqqqqqpgqnhvsujzd95jz6fyv3ldmynlf97tscs9nqqqq49en6w | 000000000000000005009dd90e484d2d242d248c8fdbb24fe92f970c40b30000 |  0.3.1  |
|    1     | erd1qqqqqqqqqqqqqpgqysmcsfkqed279x6jvs694th4e4v50p4pqqqsxwywm0 | 0000000000000000050024378826c0cb55e29b5264345aaef5cd594786a10001 |  0.3.1  |
|    2     | erd1qqqqqqqqqqqqqpgqnk5fq8sgg4vc63ffzf7qez550xe2l5jgqqpqe53dcq | 000000000000000005009da8901e0845598d4529127c0c8a9479b2afd2480002 |  0.3.1  |
|    3     | erd1qqqqqqqqqqqqqpgqvccl0w78cvr48et3z0n06t8httkp97dkqqpsr49446 | 000000000000000005006631f7bbc7c30753e57113e6fd2cf75aec12f9b60003 |  0.3.1  |
|    4     | erd1qqqqqqqqqqqqqpgqpzjulx7pemmknndegp2m60vgse3q99zrqqzqlg6cex | 0000000000000000050008a5cf9bc1cef769cdb94055bd3d8886620294430004 |  0.3.1  |
|    5     | erd1qqqqqqqqqqqqqpgqjr24m738s30aajdv6f5xmzuyxnss8txuqqzs59pwcn | 0000000000000000050090d55dfa27845fdec9acd2686d8b8434e103acdc0005 |  0.3.1  |
|    6     | erd1qqqqqqqqqqqqqpgqhcm9k2xkk75e47wpmvfgj8fuzwaguvzyqqrqsteg8w | 00000000000000000500be365b28d6b7a99af9c1db12891d3c13ba8e30440006 |  0.3.1  |
|    7     | erd1qqqqqqqqqqqqqpgql2p9sdutmz2vp6w0w5e4f3hjt9wekucvqqrs6ds80n | 00000000000000000500fa8258378bd894c0e9cf753354c6f2595d9b730c0007 |  0.3.1  |
|    8     | erd1qqqqqqqqqqqqqpgq37fmv57uqkayxctplh4swkw9vfz2jawvqqyqdugcju | 000000000000000005008f93b653dc05ba436161fdeb0759c56244a975cc0008 |  0.3.1  |
|    9     | erd1qqqqqqqqqqqqqpgqlk3vuqlqydznh94ufpt2sy9j4d0u22umqqys9qzvlh | 00000000000000000500fda2ce03e023453b96bc4856a810b2ab5fc52b9b0009 |  0.3.1  |
|    10    | erd1qqqqqqqqqqqqqpgqup6wn264pz9c02vklwwrelhtkqydfmh0qq9qpfkpx0 | 00000000000000000500e074e9ab55088b87a996fb9c3cfeebb008d4eeef000a |  0.3.1  |
|    11    | erd1qqqqqqqqqqqqqpgq57ekvv62qxhutavp4glfkljkayu8r8rxqq9squkq2x | 00000000000000000500a7b366334a01afc5f581aa3e9b7e56e938719c66000b |  0.3.1  |
...
```