### PR TITLE
Fixed addNodes signature for Delegation Manager created contracts

### DIFF
--- a/erdpy/cli_delagation.py
+++ b/erdpy/cli_delagation.py
@@ -36,7 +36,7 @@ def setup_parser(subparsers: Any) -> Any:
                                            "Add new nodes must be called by the contract owner")
     sub.add_argument("--validators-file", required=True, help="a JSON file describing the Nodes")
     sub.add_argument("--delegation-contract", required=True, help="address of the delegation contract")
-    sub.add_argument("--using-dm", action="store_true", required=False, help="whether delegation contract was created using the Delegation Manager")
+    sub.add_argument("--using-delegation-manager", action="store_true", required=False, help="whether delegation contract was created using the Delegation Manager")
     _add_common_arguments(sub)
     sub.set_defaults(func=add_new_nodes)
 

--- a/erdpy/cli_delagation.py
+++ b/erdpy/cli_delagation.py
@@ -36,6 +36,7 @@ def setup_parser(subparsers: Any) -> Any:
                                            "Add new nodes must be called by the contract owner")
     sub.add_argument("--validators-file", required=True, help="a JSON file describing the Nodes")
     sub.add_argument("--delegation-contract", required=True, help="address of the delegation contract")
+    sub.add_argument("--using-dm", action="store_true", required=False, help="whether delegation contract was created using the Delegation Manager")
     _add_common_arguments(sub)
     sub.set_defaults(func=add_new_nodes)
 

--- a/erdpy/delegation/staking_provider.py
+++ b/erdpy/delegation/staking_provider.py
@@ -29,7 +29,9 @@ def prepare_args_for_add_nodes(args: Any):
     validators_file = ValidatorsFile(args.validators_file)
 
     # TODO: Refactor, so that only address is received here.
-    if args.pem:
+    if args.using_dm:
+        account = Account(address=args.delegation_contract)
+    elif args.pem:
         account = Account(pem_file=args.pem)
     elif args.keyfile and args.passfile:
         account = Account(key_file=args.keyfile, pass_file=args.passfile)
@@ -41,7 +43,9 @@ def prepare_args_for_add_nodes(args: Any):
         validator_pem = validator.get("pemFile")
         validator_pem = path.join(path.dirname(args.validators_file), validator_pem)
         seed, bls_key = parse_validator_pem(validator_pem)
-        signed_message = sign_message_with_bls_key(account.address.pubkey().hex(), seed.hex())
+        if (not args.using_dm):
+            seed = seed.hex()
+        signed_message = sign_message_with_bls_key(account.address.pubkey().hex(), seed)
         add_nodes_data += f"@{bls_key}@{signed_message}"
 
     args.receiver = args.delegation_contract

--- a/erdpy/delegation/staking_provider.py
+++ b/erdpy/delegation/staking_provider.py
@@ -43,7 +43,7 @@ def prepare_args_for_add_nodes(args: Any):
         validator_pem = validator.get("pemFile")
         validator_pem = path.join(path.dirname(args.validators_file), validator_pem)
         seed, bls_key = parse_validator_pem(validator_pem)
-        if (not args.using_delegation_manager):
+        if not args.using_delegation_manager:
             seed = seed.hex()
         signed_message = sign_message_with_bls_key(account.address.pubkey().hex(), seed)
         add_nodes_data += f"@{bls_key}@{signed_message}"

--- a/erdpy/delegation/staking_provider.py
+++ b/erdpy/delegation/staking_provider.py
@@ -29,7 +29,7 @@ def prepare_args_for_add_nodes(args: Any):
     validators_file = ValidatorsFile(args.validators_file)
 
     # TODO: Refactor, so that only address is received here.
-    if args.using_dm:
+    if args.using_delegation_manager:
         account = Account(address=args.delegation_contract)
     elif args.pem:
         account = Account(pem_file=args.pem)
@@ -43,7 +43,7 @@ def prepare_args_for_add_nodes(args: Any):
         validator_pem = validator.get("pemFile")
         validator_pem = path.join(path.dirname(args.validators_file), validator_pem)
         seed, bls_key = parse_validator_pem(validator_pem)
-        if (not args.using_dm):
+        if (not args.using_delegation_manager):
             seed = seed.hex()
         signed_message = sign_message_with_bls_key(account.address.pubkey().hex(), seed)
         add_nodes_data += f"@{bls_key}@{signed_message}"

--- a/erdpy/delegation/staking_provider.py
+++ b/erdpy/delegation/staking_provider.py
@@ -43,9 +43,7 @@ def prepare_args_for_add_nodes(args: Any):
         validator_pem = validator.get("pemFile")
         validator_pem = path.join(path.dirname(args.validators_file), validator_pem)
         seed, bls_key = parse_validator_pem(validator_pem)
-        if not args.using_delegation_manager:
-            seed = seed.hex()
-        signed_message = sign_message_with_bls_key(account.address.pubkey().hex(), seed)
+        signed_message = sign_message_with_bls_key(account.address.pubkey().hex(), seed.decode('ascii'))
         add_nodes_data += f"@{bls_key}@{signed_message}"
 
     args.receiver = args.delegation_contract

--- a/erdpy/validators/core.py
+++ b/erdpy/validators/core.py
@@ -34,7 +34,7 @@ def prepare_args_for_stake(args: Any):
         validator_pem = validator.get("pemFile")
         validator_pem = path.join(path.dirname(args.validators_file), validator_pem)
         seed, bls_key = parse_validator_pem(validator_pem)
-        signed_message = sign_message_with_bls_key(account.address.pubkey().hex(), seed.hex())
+        signed_message = sign_message_with_bls_key(account.address.pubkey().hex(), seed.decode('ascii'))
         stake_data += f"@{bls_key}@{signed_message}"
 
     if reward_address:


### PR DESCRIPTION
Delegation Smart Contracts created using the Delegation Manager expect a different signature when adding nodes. The current version only works with the SC that's active on the mainnet.

1. The key used for signing should be the Delegation Contract public key and not the contract owner
2. The validator private key should not be hexed when signing

The change adds the optional ~~`--using-dm`~~ `--using-delegation-manager` so the command does not break the previous SC interaction.