### PR TITLE
Erdpy C modularity

### DIFF
--- a/erdpy/projects/project_base.py
+++ b/erdpy/projects/project_base.py
@@ -18,7 +18,6 @@ class Project:
         self.path = Path(directory).expanduser().resolve()
         self.directory = str(self.path)
 
-
     def build(self, options=None):
         self.options = options or dict()
         self.debug = self.options.get("debug", False)
@@ -26,38 +25,30 @@ class Project:
         self.perform_build()
         self._do_after_build()
 
-
     def clean(self):
         utils.remove_folder(self._get_output_folder())
-
 
     def _ensure_dependencies_installed(self):
         module_keys = self.get_dependencies()
         for module_key in module_keys:
             dependencies.install_module(module_key)
 
-
     def get_dependencies(self) -> List[str]:
         raise NotImplementedError()
-
 
     def perform_build(self) -> None:
         raise NotImplementedError()
 
-
     def get_file_wasm(self):
         return self.find_file_in_output("*.wasm")
-
 
     def find_file_globally(self, pattern):
         folder = self.directory
         return self.find_file_in_folder(folder, pattern)
 
-
     def find_file_in_output(self, pattern):
         folder = path.join(self.directory, "output")
         return self.find_file_in_folder(folder, pattern)
-
 
     def find_file_in_folder(self, folder, pattern):
         files = list(Path(folder).rglob(pattern))
@@ -70,10 +61,8 @@ class Project:
         file = path.join(folder, files[0])
         return Path(file).resolve()
 
-
     def _do_after_build(self) -> None:
         raise NotImplementedError()
-
 
     def _copy_to_output(self, source: str, destination: str = None):
         output_folder = self._get_output_folder()
@@ -81,26 +70,21 @@ class Project:
         destination = path.join(output_folder, destination) if destination else output_folder
         shutil.copy(source, destination)
 
-
     def _get_output_folder(self):
         return path.join(self.directory, "output")
-
 
     def get_bytecode(self):
         bytecode = utils.read_file(self.get_file_wasm(), binary=True)
         bytecode_hex = bytecode.hex()
         return bytecode_hex
 
-
     def load_config(self):
         config_file = self.get_config_file()
         config = utils.read_json_file(str(config_file))
         return config
 
-
     def get_config_file(self):
         return self.path / 'elrond.json'
-
 
     def ensure_config_file(self):
         config_file = self.get_config_file()
@@ -108,10 +92,8 @@ class Project:
             utils.write_json_file(str(config_file), self.default_config())
             logger.info("created default configuration in elrond.json")
 
-
     def default_config(self):
         return dict()
-
 
     def run_tests(self, tests_directory: str, wildcard: str = ""):
         arwentools = cast(StandaloneModule, dependencies.get_module_by_key("arwentools"))

--- a/erdpy/projects/project_clang.py
+++ b/erdpy/projects/project_clang.py
@@ -119,8 +119,12 @@ class ProjectClang(Project):
 
 
     def get_source_files(self):
-        for filename in self.config['source_files']:
-            yield Path(filename).expanduser().resolve()
+        try:
+            source_files = self.config['source_files']
+            for filename in source_files:
+                yield Path(filename).expanduser().resolve()
+        except KeyError:
+            return self.path.rglob('*.c')
 
 
     def get_ll_files(self):
@@ -129,7 +133,8 @@ class ProjectClang(Project):
 
 
     def get_unit_file(self):
-        return next(self.get_source_files())
+        first_file = next(self.get_source_files())
+        return first_file
 
 
     def get_exported_functions(self):

--- a/erdpy/projects/project_clang.py
+++ b/erdpy/projects/project_clang.py
@@ -16,7 +16,6 @@ class ProjectClang(Project):
         super().__init__(directory)
         self.ensure_config_file()
 
-
     def perform_build(self):
         self.config = self.load_config()
         self.ensure_source_files()
@@ -34,7 +33,6 @@ class ProjectClang(Project):
             self.do_wasm()
         except subprocess.CalledProcessError as err:
             raise errors.BuildError(err.output)
-
 
     def do_clang(self):
         logger.info('do_clang')
@@ -54,7 +52,6 @@ class ProjectClang(Project):
         args.extend(map(str, self.get_source_files()))
         myprocess.run_process(args)
 
-
     def do_llvm_link(self):
         logger.info('do_llvm_link')
         tool = path.join(self._get_llvm_path(), 'llvm-link')
@@ -62,7 +59,6 @@ class ProjectClang(Project):
         args.extend(['-o', str(self.file_ll)])
         args.extend(map(str, self.get_ll_files()))
         myprocess.run_process(args)
-
 
     def do_llc(self):
         logger.info('do_llc')
@@ -79,7 +75,6 @@ class ProjectClang(Project):
 
         args.extend(['-o', str(self.file_o)])
         myprocess.run_process(args)
-
 
     def do_wasm(self):
         logger.info('do_wasm')
@@ -103,7 +98,6 @@ class ProjectClang(Project):
 
         myprocess.run_process(args)
 
-
     def _do_after_build(self):
         self._copy_to_output(self.file_output)
         self.file_output.unlink()
@@ -115,25 +109,20 @@ class ProjectClang(Project):
             except FileNotFoundError:
                 pass
 
-
     def _get_llvm_path(self):
         return dependencies.get_module_directory('llvm')
-
 
     def get_source_files(self):
         for filename in self.config['source_files']:
             yield (self.path / filename).expanduser().resolve()
 
-
     def get_ll_files(self):
         for source_file in self.get_source_files():
             yield source_file.with_suffix('.ll')
 
-
     def get_unit_file(self):
         first_file = next(self.get_source_files())
         return first_file
-
 
     def ensure_source_files(self):
         try:
@@ -145,12 +134,10 @@ class ProjectClang(Project):
 
         self.config['source_files'] = source_files
 
-
     def get_exported_functions(self):
         file_export = self.find_file_globally('*.export')
         lines = utils.read_lines(file_export)
         return lines
-
 
     def default_config(self):
         config = super().default_config()
@@ -158,10 +145,8 @@ class ProjectClang(Project):
         config['source_files'] = self.get_source_files_from_folder()
         return config
 
-
     def get_source_files_from_folder(self):
         return list(map(str, self.path.rglob('*.c')))
-
 
     def get_dependencies(self):
         return ['llvm']

--- a/erdpy/projects/project_clang.py
+++ b/erdpy/projects/project_clang.py
@@ -153,7 +153,6 @@ class ProjectClang(Project):
 
 
     def default_config(self):
-        default_main_source = self.path.name + '.c'
         config = super().default_config()
         config['language'] = 'clang'
         config['source_files'] = self.get_source_files_from_folder()

--- a/erdpy/projects/project_clang.py
+++ b/erdpy/projects/project_clang.py
@@ -124,7 +124,8 @@ class ProjectClang(Project):
             for filename in source_files:
                 yield Path(filename).expanduser().resolve()
         except KeyError:
-            return self.path.rglob('*.c')
+            for filename in self.path.rglob('*.c'):
+                yield filename
 
 
     def get_ll_files(self):

--- a/erdpy/projects/project_clang.py
+++ b/erdpy/projects/project_clang.py
@@ -7,94 +7,144 @@ from pathlib import Path
 from erdpy import dependencies, errors, myprocess, utils
 from erdpy.projects.project_base import Project
 
-logger = logging.getLogger("ProjectClang")
+logger = logging.getLogger('ProjectClang')
 
 
 class ProjectClang(Project):
+
     def __init__(self, directory):
         super().__init__(directory)
+        self.ensure_config_file()
+
 
     def perform_build(self):
-        self.build_configuration = ClangBuildConfiguration(self, self.debug)
-        self.unit = self.find_file_globally("*.c")
-        self.file_ll = self.unit.with_suffix(".ll")
-        self.file_o = self.unit.with_suffix(".o")
-        self.file_export = self.unit.with_suffix(".export")
+        self.config = self.load_config()
+        self.unit = self.get_unit_file()
+        self.file_ll = self.unit.with_suffix('.ll')
+        self.file_o = self.unit.with_suffix('.o')
+        self.file_export = self.unit.with_suffix('.export')
+        self.file_output = self.unit.with_suffix('.wasm')
 
         try:
-            self._do_clang()
-            self._do_llc()
-            self._do_wasm()
+            self.do_clang()
+            self.do_llvm_link()
+            self.do_llc()
+            self.do_wasm()
         except subprocess.CalledProcessError as err:
             raise errors.BuildError(err.output)
 
-    def _do_clang(self):
-        logger.info("_do_clang")
-        tool = path.join(self._get_llvm_path(), "clang-9")
+
+    def do_clang(self):
+        logger.info('do_clang')
+
+        tool = path.join(self._get_llvm_path(), 'clang-9')
         args = [
             tool,
-            "-cc1", "-emit-llvm",
-            "-triple=wasm32-unknown-unknown-wasm",
+            '-cc1', '-emit-llvm',
+            '-triple=wasm32-unknown-unknown-wasm',
         ]
-        if self.options.get("optimized", False):
-            args.append("-Ofast")
+
+        if self.options.get('optimized', False):
+            args.append('-Ofast')
         else:
-            args.append("-O0")
-        args.append(str(self.unit))
+            args.append('-O0')
+
+        args.extend(map(str, self.get_source_files()))
         myprocess.run_process(args)
 
-    def _do_llc(self):
-        logger.info("_do_llc")
-        tool = path.join(self._get_llvm_path(), "llc")
+
+    def do_llvm_link(self):
+        logger.info('do_llvm_link')
+        tool = path.join(self._get_llvm_path(), 'llvm-link')
         args = [tool]
-        if self.options.get("optimized", False):
-            args.append("-O3")
-        else:
-            args.append("-O0")
-        args.extend(["-filetype=obj", self.file_ll, "-o", self.file_o])
+        args.extend(['-o', str(self.file_ll)])
+        args.extend(map(str, self.get_ll_files()))
         myprocess.run_process(args)
 
-    def _do_wasm(self):
-        logger.info("_do_wasm")
-        tool = path.join(self._get_llvm_path(), "wasm-ld")
+
+    def do_llc(self):
+        logger.info('do_llc')
+        tool = path.join(self._get_llvm_path(), 'llc')
+        args = [tool]
+
+        if self.options.get('optimized', False):
+            args.append('-O3')
+        else:
+            args.append('-O0')
+
+        args.append('-filetype=obj')
+        args.append(str(self.file_ll))
+
+        args.extend(['-o', str(self.file_o)])
+        myprocess.run_process(args)
+
+
+    def do_wasm(self):
+        logger.info('do_wasm')
+        tool = path.join(self._get_llvm_path(), 'wasm-ld')
         args = [
             tool,
-            "--no-entry",
+            '--no-entry',
             str(self.file_o),
-            "-o", self.find_file_globally("*.c").with_suffix(".wasm"),
-            "--strip-all",
-            "-allow-undefined"
+            '-o', self.file_output,
+            '--strip-all',
+            '-allow-undefined'
         ]
 
-        if self.options.get("verbose", False):
-            args.append("--verbose")
+        if self.options.get('verbose', False):
+            args.append('--verbose')
 
-        for export in self.build_configuration.exports:
-            args.append(f"-export={export}")
+        logger.info('exported functions:')
+        for export in self.get_exported_functions():
+            logger.info(f'\t{export}')
+            args.append(f'-export={export}')
 
         myprocess.run_process(args)
+
 
     def _do_after_build(self):
-        source_file = self.find_file_globally("*.c")
-        self._copy_to_output(source_file.with_suffix(".wasm"))
-        os.remove(source_file.with_suffix(".wasm"))
-        os.remove(source_file.with_suffix(".ll"))
-        os.remove(source_file.with_suffix(".o"))
+        self._copy_to_output(self.file_output)
+        self.file_output.unlink()
+        self.file_ll.unlink()
+        self.file_o.unlink()
+        for ll_file in self.get_ll_files():
+            try:
+                ll_file.unlink()
+            except FileNotFoundError:
+                pass
+
 
     def _get_llvm_path(self):
-        return dependencies.get_module_directory("llvm")
-
-    def get_dependencies(self):
-        return ["llvm"]
+        return dependencies.get_module_directory('llvm')
 
 
-class ClangBuildConfiguration:
-    def __init__(self, project, debug):
-        self.project = project
-        self.debug = debug
-        self.exports = self._get_exports()
+    def get_source_files(self):
+        for filename in self.config['source_files']:
+            yield Path(filename).expanduser().resolve()
 
-    def _get_exports(self):
-        file_export = self.project.find_file_globally("*.export")
+
+    def get_ll_files(self):
+        for source_file in self.get_source_files():
+            yield source_file.with_suffix('.ll')
+
+
+    def get_unit_file(self):
+        return next(self.get_source_files())
+
+
+    def get_exported_functions(self):
+        file_export = self.find_file_globally('*.export')
         lines = utils.read_lines(file_export)
         return lines
+
+
+    def default_config(self):
+        default_main_source = self.path.name + '.c'
+        config = super().default_config()
+        config['language'] = 'clang'
+        config['source_files'] = [default_main_source]
+        return config
+
+
+    def get_dependencies(self):
+        return ['llvm']

--- a/erdpy/projects/project_sol.py
+++ b/erdpy/projects/project_sol.py
@@ -88,7 +88,7 @@ class ProjectSol(Project):
 
         tool = path.join(self._get_llvm_path(), "wasm-ld")
         args = [
-            tool, 
+            tool,
             "--entry",
             "main",
             "--demangle",


### PR DESCRIPTION
This PR allows smart contracts written in C to be broken in to multiple C files. To do so, the C files must be listed in `elrond.json`, in the `source_files` field. The first file listed in `source_files` is by definition the "unit" of the project, i.e. the main file. As a convention, the main file should contain all the exported functions, but this is not a hard requirement.

If the file `erdpy.json` is not present in the smart contract folder, it will be created automatically by `erdpy`. By default, the `source_files` field will be populated with all the C files in the folder. Afterwards, the `source_files` list can be changed to anything afterwards.

If `erdpy.json` already exists but does not contain the `source_files` field, all files of the form `*.c` are considered source files automatically. The `erdpy.json` file itself will NOT be updated if already present.

Example `erdpy.json`:

```
{
    "language": "clang",
    "source_files": [
        "main_source_file.c",
	"another_part.c",
        "subfolder/more_code.c",
        "../../../common/utilities/tools.c"
    ]
}
```


