### PR TITLE
Fix compatibility with the latest elrond-go

### DIFF
--- a/erdgo/go.mod
+++ b/erdgo/go.mod
@@ -4,9 +4,13 @@ go 1.14
 
 require (
 	github.com/ElrondNetwork/elrond-go v1.1.50
+	github.com/ElrondNetwork/elrond-go-logger v1.0.4
+	github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 // indirect
+	github.com/alecthomas/units v0.0.0-20210208195552-ff826a37aa15 // indirect
 	github.com/btcsuite/btcutil v1.0.2 // indirect
 	github.com/pborman/uuid v1.2.1
 	github.com/stretchr/testify v1.7.0
 	github.com/tyler-smith/go-bip39 v1.1.0
 	golang.org/x/crypto v0.0.0-20201203163018-be400aefbc4c
+	gopkg.in/alecthomas/kingpin.v2 v2.2.6 // indirect
 )

--- a/erdgo/go.mod
+++ b/erdgo/go.mod
@@ -3,7 +3,7 @@ module github.com/ElrondNetwork/elrond-sdk/erdgo
 go 1.14
 
 require (
-	github.com/ElrondNetwork/elrond-go v1.1.37
+	github.com/ElrondNetwork/elrond-go v1.1.50
 	github.com/btcsuite/btcutil v1.0.2 // indirect
 	github.com/pborman/uuid v1.2.1
 	github.com/stretchr/testify v1.7.0

--- a/erdgo/storage/mapCacher.go
+++ b/erdgo/storage/mapCacher.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"bytes"
 	"encoding/gob"
+	"github.com/prometheus/common/log"
 	"sync"
 )
 
@@ -132,7 +133,9 @@ func (mc *mapCacher) SizeInBytesContained() uint64 {
 	total := 0
 	b := new(bytes.Buffer)
 	for _, v := range mc.dataMap {
-		if err := gob.NewEncoder(b).Encode(v); err != nil {
+		var err = gob.NewEncoder(b).Encode(v)
+		if err != nil {
+			log.Error(err.Error())
 			total += 0
 		} else {
 			total += b.Len()

--- a/erdgo/storage/mapCacher.go
+++ b/erdgo/storage/mapCacher.go
@@ -3,9 +3,12 @@ package storage
 import (
 	"bytes"
 	"encoding/gob"
-	"github.com/prometheus/common/log"
 	"sync"
+
+	logger "github.com/ElrondNetwork/elrond-go-logger"
 )
+
+var log = logger.GetOrCreate("mapCacher")
 
 // mapCacher is the cacher implementation based on a map
 type mapCacher struct {

--- a/erdgo/storage/mapCacher.go
+++ b/erdgo/storage/mapCacher.go
@@ -1,6 +1,8 @@
 package storage
 
 import (
+	"bytes"
+	"encoding/gob"
 	"sync"
 )
 
@@ -120,6 +122,24 @@ func (mc *mapCacher) Len() int {
 	defer mc.RUnlock()
 
 	return len(mc.dataMap)
+}
+
+// SizeInBytesContained returns the size in bytes of all contained elements
+func (mc *mapCacher) SizeInBytesContained() uint64 {
+	mc.RLock()
+	defer mc.RUnlock()
+
+	total := 0
+	b := new(bytes.Buffer)
+	for _, v := range mc.dataMap {
+		if err := gob.NewEncoder(b).Encode(v); err != nil {
+			total += 0
+		} else {
+			total += b.Len()
+		}
+	}
+
+	return uint64(total)
 }
 
 // MaxSize returns the maximum number of items which can be stored in cache.

--- a/erdgo/tests/mapCacher_test.go
+++ b/erdgo/tests/mapCacher_test.go
@@ -1,9 +1,10 @@
 package tests
 
 import (
+	"testing"
+
 	"github.com/ElrondNetwork/elrond-sdk/erdgo/storage"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func TestSizeInBytesContained(t *testing.T) {

--- a/erdgo/tests/mapCacher_test.go
+++ b/erdgo/tests/mapCacher_test.go
@@ -1,0 +1,14 @@
+package tests
+
+import (
+	"github.com/ElrondNetwork/elrond-sdk/erdgo/storage"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestSizeInBytesContained(t *testing.T) {
+	cacher := storage.NewMapCacher()
+	cacher.Put([]byte("key"), "value", 0)
+
+	assert.Equal(t, uint64(9), cacher.SizeInBytesContained())
+}


### PR DESCRIPTION
The storage inteface has changed in the latest minor update of elrond-go and that broke the sdk.