### PR TITLE
Kotlin SDK : version 0.3.0

### DIFF
--- a/erdkotlin/CHANGELOG.md
+++ b/erdkotlin/CHANGELOG.md
@@ -1,10 +1,18 @@
 Changelog
 ============
 
+## [0.3.0] - 03.02.2021
+Add several fields to `NetworkConfig`  
+Add `code` and `username` fields to `Account`  
+Add `option` field to Transaction  
+The OkHttpClient internally used by the SDK is now configurable from the host App through its builder  
+Crash fix when address/:bech32Address/transactions would return no data.  
+Update Kotlin version to 1.4.31  
+
 ## [0.2.0] - 03.02.2021
 
-Add a `.pom` file for `.jar` building. (more infos in the readme)
-Add support for Dns username: `Transaction.senderUsername` and `Transaction.receiverUsername`
+Add a `.pom` file for `.jar` building. (more infos in the readme)  
+Add support for Dns username: `Transaction.senderUsername` and `Transaction.receiverUsername`  
 
 Implement the following endpoints through usecases
 - GetAddressNonceUsecase - GET address/:bech32Address/nonce
@@ -15,13 +23,13 @@ Implement the following endpoints through usecases
 - GetTransactionStatusUsecase - GET transaction/:txHash/status
 - QuerySmartContractUsecase - POST vm-values/query (Compute Output of Pure Function)
 
-Add the folowing usecases :
+Add the folowing usecases :  
 - RegisterDnsUsecase // equivalent to `erdpy dns register`
 - GetDnsRegistrationCostUsecase // equivalent to `erdpy dns registration-cost`
 
 ## [0.1.0] - 26.01.2021
 
-Initial version allowing to import a wallet and send transaction.
+Initial version allowing to import a wallet and send transaction.  
 
 Usecases:
 - GetAccountUsecase

--- a/erdkotlin/README.md
+++ b/erdkotlin/README.md
@@ -6,10 +6,8 @@ This is the kotlin implementation of Elrond SDK
 
 This project was primarily designed for Android but is also compatible with any Kotlin-friendly app since it doesn't use the Android SDK
 
-This is still a work in progress.
-
 ## Usage
-This SDK is built with the clean architecture principles.
+This SDK is built with the clean architecture principles.  
 Interaction are done through usecases
 
 Here is an example for sending a transaction.
@@ -37,22 +35,28 @@ val transaction = Transaction(
 
 // Send transaction.
 // Signature is handled internally
-ErdSdk.sendTransactionUsecase().execute(transaction, wallet).also { sentTransaction ->
-    Log.d("Transaction", "tx:${sentTransaction.txHash}")
-}
+val sentTransaction = ErdSdk.sendTransactionUsecase().execute(transaction, wallet)
+Log.d("Transaction", "tx:${sentTransaction.txHash}")
 ```
 
-In a real world example, the usescases would be injected
-The sample application showcase how to do it on Android with Hilt framework (see the [Complete Example](#complete-example) section).
+In a real world example, the usescases would be injected  
+The sample application showcase how to do it on Android with Hilt framework (see the [Sample App](#sample-app)).
 
 
 ## Configuration
 ```
-ErdSdk.setNetwork(ProviderUrl.MainNet) // default value is ProviderUrl.DevNet
+// default value is ProviderUrl.DevNet
+ErdSdk.setNetwork(ProviderUrl.MainNet)
+
+// configure the OkHttpClient
+ErdSdk.elrondHttpClientBuilder.apply {
+    addInterceptor(HttpLoggingInterceptor())
+}
 ```
 
 ## Build
-You can build the jar from the sources with `mvn package`
+The SDK is not yet uploaded to a maven repository  
+You can build the jar from the sources by running `mvn package`
 
-## Complete Example
+## Sample App
 For a complete example you can checkout this [sample application](https://github.com/Alexandre-saddour/ElrondKotlinSampleApp)

--- a/erdkotlin/pom.xml
+++ b/erdkotlin/pom.xml
@@ -15,7 +15,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.7</maven.compiler.source>
         <maven.compiler.target>1.7</maven.compiler.target>
-        <kotlin.version>1.4.21-2</kotlin.version>
+        <kotlin.version>1.4.31</kotlin.version>
     </properties>
 
     <dependencies>

--- a/erdkotlin/pom.xml
+++ b/erdkotlin/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>elrond</groupId>
     <artifactId>erdkotlin</artifactId>
-    <version>0.2.0</version>
+    <version>0.3.0</version>
 
     <name>erdkotlin</name>
     <url>https://github.com/ElrondNetwork/elrond-sdk</url>

--- a/erdkotlin/src/main/java/com/elrond/erdkotlin/ErdSdk.kt
+++ b/erdkotlin/src/main/java/com/elrond/erdkotlin/ErdSdk.kt
@@ -16,6 +16,7 @@ import com.elrond.erdkotlin.domain.transaction.*
 import com.elrond.erdkotlin.domain.transaction.SignTransactionUsecase
 import com.elrond.erdkotlin.domain.dns.GetDnsRegistrationCostUsecase
 import com.elrond.erdkotlin.domain.vm.QuerySmartContractUsecase
+import okhttp3.OkHttpClient
 
 // Implemented as an `object` because we are not using any dependency injection library
 // We don't want to force the host app to use a specific library.
@@ -54,7 +55,8 @@ object ErdSdk {
 
     internal fun computeDnsAddressUsecase() = ComputeDnsAddressUsecase(checkUsernameUsecase())
 
-    private val elrondProxy = ElrondProxy(ElrondNetwork.DevNet.url())
+    val elrondHttpClientBuilder = OkHttpClient.Builder()
+    private val elrondProxy = ElrondProxy(ElrondNetwork.DevNet.url(), elrondHttpClientBuilder)
     private val networkConfigRepository = NetworkConfigRepositoryImpl(elrondProxy)
     private val accountRepository = AccountRepositoryImpl(elrondProxy)
     private val transactionRepository = TransactionRepositoryImpl(elrondProxy)

--- a/erdkotlin/src/main/java/com/elrond/erdkotlin/data/DataMappers.kt
+++ b/erdkotlin/src/main/java/com/elrond/erdkotlin/data/DataMappers.kt
@@ -16,6 +16,8 @@ internal fun GetAccountResponse.AccountData.toDomain(address: Address) = Account
     address = address,
     nonce = nonce,
     balance = balance,
+    code = code,
+    username = username
 )
 
 internal fun GetAddressTransactionsResponse.TransactionOnNetworkData.toDomain() =

--- a/erdkotlin/src/main/java/com/elrond/erdkotlin/data/DataMappers.kt
+++ b/erdkotlin/src/main/java/com/elrond/erdkotlin/data/DataMappers.kt
@@ -78,9 +78,22 @@ internal fun QueryContractResponse.Data.toDomain() = SmartContractOutput(
 
 internal fun GetNetworkConfigResponse.NetworkConfigData.toDomain() = NetworkConfig(
     chainID = chainID,
+    erdDenomination = erdDenomination,
     gasPerDataByte = gasPerDataByte,
+    erdGasPriceModifier = erdGasPriceModifier,
+    erdLatestTagSoftwareVersion = erdLatestTagSoftwareVersion,
+    erdMetaConsensusGroupSize = erdMetaConsensusGroupSize,
     minGasLimit = minGasLimit,
     minGasPrice = minGasPrice,
-    minTransactionVersion = minTransactionVersion
+    minTransactionVersion = minTransactionVersion,
+    erdNumMetachainNodes = erdNumMetachainNodes,
+    erdNumNodesInShard = erdNumNodesInShard,
+    erdNumShardsWithoutMeta = erdNumShardsWithoutMeta,
+    erdRewardsTopUpGradientPoint = erdRewardsTopUpGradientPoint,
+    erdRoundDuration = erdRoundDuration,
+    erdRoundsPerEpoch = erdRoundsPerEpoch,
+    erdShardConsensusGroupSize = erdShardConsensusGroupSize,
+    erdStartTime = erdStartTime,
+    erdTopUpFactor = erdTopUpFactor
 )
 

--- a/erdkotlin/src/main/java/com/elrond/erdkotlin/data/account/responses/GetAccountResponse.kt
+++ b/erdkotlin/src/main/java/com/elrond/erdkotlin/data/account/responses/GetAccountResponse.kt
@@ -7,6 +7,8 @@ internal data class GetAccountResponse(
 ) {
     internal data class AccountData(
         val nonce: Long,
-        val balance: BigInteger
+        val balance: BigInteger,
+        val code: String?,
+        val username: String?
     )
 }

--- a/erdkotlin/src/main/java/com/elrond/erdkotlin/data/api/ElrondClient.kt
+++ b/erdkotlin/src/main/java/com/elrond/erdkotlin/data/api/ElrondClient.kt
@@ -11,10 +11,11 @@ import java.io.IOException
 
 internal class ElrondClient(
     var url: String,
-    private val gson: Gson
-) {
+    private val gson: Gson,
+    httpClientBuilder: OkHttpClient.Builder = OkHttpClient.Builder()
 
-    private val httpClient = OkHttpClient()
+) {
+    private val httpClient: OkHttpClient by lazy { httpClientBuilder.build() }
 
     @Throws(IOException::class)
     inline fun <reified T : ResponseBase<*>> doGet(resourceUrl: String): T {

--- a/erdkotlin/src/main/java/com/elrond/erdkotlin/data/api/ElrondProxy.kt
+++ b/erdkotlin/src/main/java/com/elrond/erdkotlin/data/api/ElrondProxy.kt
@@ -14,13 +14,15 @@ import com.elrond.erdkotlin.data.vm.responses.QueryContractResponse
 import com.elrond.erdkotlin.domain.transaction.models.Transaction
 import com.elrond.erdkotlin.domain.wallet.models.Address
 import com.google.gson.Gson
+import okhttp3.OkHttpClient
 
 internal class ElrondProxy(
-    url: String
+    url: String,
+    httpClientBuilder: OkHttpClient.Builder = OkHttpClient.Builder()
 ) {
 
     private val gson = Gson()
-    private val elrondClient = ElrondClient(url, gson)
+    private val elrondClient = ElrondClient(url, gson, httpClientBuilder)
 
     fun setUrl(url: String) {
         elrondClient.url = url

--- a/erdkotlin/src/main/java/com/elrond/erdkotlin/data/networkconfig/GetNetworkConfigResponse.kt
+++ b/erdkotlin/src/main/java/com/elrond/erdkotlin/data/networkconfig/GetNetworkConfigResponse.kt
@@ -8,13 +8,40 @@ internal data class GetNetworkConfigResponse(
     internal data class NetworkConfigData(
         @SerializedName(value = "erd_chain_id")
         val chainID: String,
+        @SerializedName(value = "erd_denomination")
+        val erdDenomination: Int,
         @SerializedName(value = "erd_gas_per_data_byte")
         val gasPerDataByte: Int,
+        @SerializedName(value = "erd_gas_price_modifier")
+        val erdGasPriceModifier: Double,
+        @SerializedName(value = "erd_latest_tag_software_version")
+        val erdLatestTagSoftwareVersion: String,
+        @SerializedName(value = "erd_meta_consensus_group_size")
+        val erdMetaConsensusGroupSize: Long,
         @SerializedName(value = "erd_min_gas_limit")
         val minGasLimit: Long,
         @SerializedName(value = "erd_min_gas_price")
         val minGasPrice: Long,
         @SerializedName(value = "erd_min_transaction_version")
-        val minTransactionVersion: Int
+        val minTransactionVersion: Int,
+        @SerializedName(value = "erd_num_metachain_nodes")
+        val erdNumMetachainNodes: Long,
+        @SerializedName(value = "erd_num_nodes_in_shard")
+        val erdNumNodesInShard: Long,
+        @SerializedName(value = "erd_num_shards_without_meta")
+        val erdNumShardsWithoutMeta: Int,
+        @SerializedName(value = "erd_rewards_top_up_gradient_point")
+        val erdRewardsTopUpGradientPoint: String,
+        @SerializedName(value = "erd_round_duration")
+        val erdRoundDuration: Long,
+        @SerializedName(value = "erd_rounds_per_epoch")
+        val erdRoundsPerEpoch: Long,
+        @SerializedName(value = "erd_shard_consensus_group_size")
+        val erdShardConsensusGroupSize: Long,
+        @SerializedName(value = "erd_start_time")
+        val erdStartTime: Long,
+        @SerializedName(value = "erd_top_up_factor")
+        val erdTopUpFactor: String
     )
 }
+

--- a/erdkotlin/src/main/java/com/elrond/erdkotlin/data/transaction/TransactionRepositoryImpl.kt
+++ b/erdkotlin/src/main/java/com/elrond/erdkotlin/data/transaction/TransactionRepositoryImpl.kt
@@ -24,7 +24,7 @@ internal class TransactionRepositoryImpl(
 
     override fun getTransactions(address: Address): List<TransactionOnNetwork> {
         val response = elrondProxy.getAddressTransactions(address)
-        return requireNotNull(response.data).transactions.map { it.toDomain() }
+        return response.data?.transactions?.map { it.toDomain() } ?: emptyList()
     }
 
     override fun estimateCostOfTransaction(transaction: Transaction): String {

--- a/erdkotlin/src/main/java/com/elrond/erdkotlin/domain/account/models/Account.kt
+++ b/erdkotlin/src/main/java/com/elrond/erdkotlin/domain/account/models/Account.kt
@@ -7,6 +7,8 @@ data class Account(
     val address: Address,
     val nonce: Long = 0,
     val balance: BigInteger = 0.toBigInteger(),
+    val code: String? = null,
+    val username: String? = null
 ) {
     // keep it to allow companion extension
     companion object

--- a/erdkotlin/src/main/java/com/elrond/erdkotlin/domain/networkconfig/models/NetworkConfig.kt
+++ b/erdkotlin/src/main/java/com/elrond/erdkotlin/domain/networkconfig/models/NetworkConfig.kt
@@ -1,11 +1,24 @@
 package com.elrond.erdkotlin.domain.networkconfig.models
 
 data class NetworkConfig(
-    var chainID: String,
-    var gasPerDataByte: Int,
-    var minGasLimit: Long,
-    var minGasPrice: Long,
-    var minTransactionVersion: Int
+    val chainID: String,
+    val erdDenomination: Int,
+    val gasPerDataByte: Int,
+    val erdGasPriceModifier: Double,
+    val erdLatestTagSoftwareVersion: String,
+    val erdMetaConsensusGroupSize: Long,
+    val minGasLimit: Long,
+    val minGasPrice: Long,
+    val minTransactionVersion: Int,
+    val erdNumMetachainNodes: Long,
+    val erdNumNodesInShard: Long,
+    val erdNumShardsWithoutMeta: Int,
+    val erdRewardsTopUpGradientPoint: String,
+    val erdRoundDuration: Long,
+    val erdRoundsPerEpoch: Long,
+    val erdShardConsensusGroupSize: Long,
+    val erdStartTime: Long,
+    val erdTopUpFactor: String
 ) {
     // keep it to allow companion extension
     companion object

--- a/erdkotlin/src/main/java/com/elrond/erdkotlin/domain/transaction/models/Transaction.kt
+++ b/erdkotlin/src/main/java/com/elrond/erdkotlin/domain/transaction/models/Transaction.kt
@@ -17,8 +17,9 @@ data class Transaction(
     val value: BigInteger = 0.toBigInteger(),
     val gasPrice: Long = 1000000000,
     val gasLimit: Long = 50000,
-    val version: Int = 1,
+    val version: Version = Version.DEFAULT,
     val data: String? = null,
+    val option: Option = Option.NONE,
     val signature: String = "",
     val txHash: String = ""
 ) {
@@ -52,7 +53,10 @@ data class Transaction(
                 put("data", encode(data))
             }
             put("chainID", chainID)
-            put("version", version)
+            put("version", version.serializedValue)
+            if (option != Option.NONE) {
+                put("option", option.serializedValue)
+            }
             if (signature.isNotEmpty()) {
                 put("signature", signature)
             }
@@ -69,4 +73,19 @@ data class Transaction(
         private val gson = GsonBuilder().disableHtmlEscaping().create()
     }
 
+    enum class Version {
+        DEFAULT,
+        TX_HASH_SIGN;
+
+        // Version starts at 1 and not 0
+        val serializedValue = ordinal + 1
+    }
+
+    enum class Option {
+        NONE,
+        TX_HASH_SIGN;
+
+        // for consistency with the other enum
+        val serializedValue = ordinal
+    }
 }

--- a/erdkotlin/src/main/java/com/elrond/erdkotlin/domain/transaction/models/Transaction.kt
+++ b/erdkotlin/src/main/java/com/elrond/erdkotlin/domain/transaction/models/Transaction.kt
@@ -17,9 +17,9 @@ data class Transaction(
     val value: BigInteger = 0.toBigInteger(),
     val gasPrice: Long = 1000000000,
     val gasLimit: Long = 50000,
-    val version: Version = Version.DEFAULT,
+    val version: Int = VERSION_DEFAULT,
     val data: String? = null,
-    val option: Option = Option.NONE,
+    val option: Int = OPTION_NONE,
     val signature: String = "",
     val txHash: String = ""
 ) {
@@ -53,9 +53,9 @@ data class Transaction(
                 put("data", encode(data))
             }
             put("chainID", chainID)
-            put("version", version.serializedValue)
-            if (option != Option.NONE) {
-                put("option", option.serializedValue)
+            put("version", version)
+            if (option != OPTION_NONE) {
+                put("option", option)
             }
             if (signature.isNotEmpty()) {
                 put("signature", signature)
@@ -71,21 +71,10 @@ data class Transaction(
 
     companion object {
         private val gson = GsonBuilder().disableHtmlEscaping().create()
+        const val VERSION_DEFAULT = 1
+        const val VERSION_TX_HASH_SIGN = 2
+        const val OPTION_NONE = 0
+        const val OPTION_TX_HASH_SIGN = 1
     }
 
-    enum class Version {
-        DEFAULT,
-        TX_HASH_SIGN;
-
-        // Version starts at 1 and not 0
-        val serializedValue = ordinal + 1
-    }
-
-    enum class Option {
-        NONE,
-        TX_HASH_SIGN;
-
-        // for consistency with the other enum
-        val serializedValue = ordinal
-    }
 }

--- a/erdkotlin/src/test/java/com/elrond/erdkotlin/SignTransactionUsecaseTest.kt
+++ b/erdkotlin/src/test/java/com/elrond/erdkotlin/SignTransactionUsecaseTest.kt
@@ -7,7 +7,6 @@ import com.elrond.erdkotlin.domain.transaction.SignTransactionUsecase
 import com.elrond.erdkotlin.domain.transaction.models.Transaction
 import com.elrond.erdkotlin.domain.wallet.models.Address
 import org.junit.Assert
-import org.junit.Ignore
 import org.junit.Test
 
 class SignTransactionUsecaseTest {
@@ -85,7 +84,7 @@ class SignTransactionUsecaseTest {
     fun `sign with option`() {
         // with an option
         val transaction = TestHelper.transactionWithoutData().copy(
-            option = Transaction.Option.TX_HASH_SIGN
+            option = Transaction.OPTION_TX_HASH_SIGN
         )
         val expectedSignature =
             "c48181af13b1c51426e7e985a790f62c98cf9e0297e8d0c0b044fe3a12391381fee833e71a33ca27287ffb5191aa46235747b1164ed574297e39ae74dd26b606"

--- a/erdkotlin/src/test/java/com/elrond/erdkotlin/SignTransactionUsecaseTest.kt
+++ b/erdkotlin/src/test/java/com/elrond/erdkotlin/SignTransactionUsecaseTest.kt
@@ -81,4 +81,23 @@ class SignTransactionUsecaseTest {
         Assert.assertEquals(expectedJson, signedTransaction.serialize())
     }
 
+    @Test
+    fun `sign with option`() {
+        // with an option
+        val transaction = TestHelper.transactionWithoutData().copy(
+            option = Transaction.Option.TX_HASH_SIGN
+        )
+        val expectedSignature =
+            "c48181af13b1c51426e7e985a790f62c98cf9e0297e8d0c0b044fe3a12391381fee833e71a33ca27287ffb5191aa46235747b1164ed574297e39ae74dd26b606"
+        val expectedJson =
+            "{'nonce':8,'value':'10000000000000000000','receiver':'erd1cux02zersde0l7hhklzhywcxk4u9n4py5tdxyx7vrvhnza2r4gmq4vw35r','sender':'erd1l453hd0gt5gzdp7czpuall8ggt2dcv5zwmfdf3sd3lguxseux2fsmsgldz','gasPrice':1000000000,'gasLimit':50000,'chainID':'1','version':1,'option':1,'signature':'$expectedSignature'}".replace(
+                '\'',
+                '"'
+            )
+        val signedTransaction = SignTransactionUsecase().execute(transaction, wallet)
+
+        Assert.assertEquals(expectedSignature, signedTransaction.signature)
+        Assert.assertEquals(expectedJson, signedTransaction.serialize())
+    }
+
 }


### PR DESCRIPTION
This PR adds the following to the Kotlin SDK
- Add several fields to `NetworkConfig`  
- Add `code` and `username` fields to `Account`  
- Add `option` field to `Transaction` (+ associated unit test)
- The OkHttpClient internally used by the SDK is now configurable from the host App through its builder  
- Crash fix when address/:bech32Address/transactions would return no data.  
- Update Kotlin version to 1.4.31  